### PR TITLE
Added the parameters for the Nearest Centroid Classifier

### DIFF
--- a/blobcity/config/classifier_config.py
+++ b/blobcity/config/classifier_config.py
@@ -140,4 +140,11 @@ class classifier_config:
                 "fit_prior":{'bool':[True,False]}
             }
         ],
+        "Nearest Centroid":[
+            neighbors.NearestCentroid,
+            {
+                "metric":{'str':['l1', 'l2']}
+                "shrink_threshold":{'float':[3.0, 3.4]}
+            }
+        ],
     }


### PR DESCRIPTION
By this commit will fix the issue of #47 
Added the parameters for the Nearest Centroid Classification Model and tested it on the Pima Indians Diabetes Dataset (from 3rd data set present in the website https://machinelearningmastery.com/standard-machine-learning-datasets/ )