### PR TITLE
Added the parameters for the Nearest Centroid

### DIFF
--- a/blobcity/config/classifier_config.py
+++ b/blobcity/config/classifier_config.py
@@ -159,6 +159,13 @@ class classifier_config:
                 "n_estimators":{"int":[50,100]},
                 "learning_rate": {'float':[1e-3,0.1]},
             }
-        ] 
+        ] ,
+        "Nearest Centroid":[
+            neighbors.NearestCentroid,
+            {
+                "metric":{'str':['l1', 'l2', 'manhattan', 'euclidean']}
+                "shrink_threshold":{'float':[3.0, 3.4]}
+            }
+        ],
 
     }


### PR DESCRIPTION
By this commit will fix the issue of #47, and modified file after a discussion on previous pull request #78 
Added the parameters for the Nearest Centroid Classification Model and tested it on the Pima Indians Diabetes Dataset (from 3rd data set present in the website https://machinelearningmastery.com/standard-machine-learning-datasets/ )
