### PR TITLE
Hacktoberfest Issue-137 Drop rows with more than 50% NANs

### DIFF
--- a/blobcity/utils/Cleaner.py
+++ b/blobcity/utils/Cleaner.py
@@ -183,4 +183,3 @@ def RemoveRowsWithHighNans(dataframe):
     dataframe = dataframe.dropna( axis=0, 
                     thresh=min_count)
     return dataframe
-    


### PR DESCRIPTION
SOLVES ISSUE
This PR solves issue #137.
Drop row with 50% or more Null/Nan Value

CHANGES MADE
Added new function - RemoveRowsWithHighNans
Made changes to
"https://github.com/blobcity/autoai/blobcity/utils/Cleaner.py"

NOTE
Please consider this PR as a submission towards Hacktoberfest 2021 and add the hacktoberfest-accepted label to it if reviewed and seems fine.